### PR TITLE
Implement input filter backend

### DIFF
--- a/backend/core/input_filter.py
+++ b/backend/core/input_filter.py
@@ -1,0 +1,44 @@
+import os
+import re
+from sqlalchemy import create_engine, Column, Integer, String
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://postgres:admin123@my-postgres-postgresql.database.svc.cluster.local:5432/postgres",
+)
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(bind=engine)
+Base = declarative_base()
+
+
+class FilterRuleModel(Base):
+    __tablename__ = "filter_rules"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String, nullable=False)
+    pattern = Column(String, nullable=False)
+
+
+Base.metadata.create_all(engine)
+
+
+class InputFilter:
+    """Utility class to check if a given text contains sensitive information."""
+
+    _compiled_rules = []
+
+    @classmethod
+    def load_rules(cls) -> None:
+        """Load filter rules from the database and compile regex patterns."""
+        with SessionLocal() as session:
+            rules = session.query(FilterRuleModel).all()
+            cls._compiled_rules = [re.compile(r.pattern, re.IGNORECASE) for r in rules]
+
+    @classmethod
+    def contains_sensitive(cls, text: str) -> bool:
+        """Return True if the text matches any filter rule."""
+        if not cls._compiled_rules:
+            cls.load_rules()
+        return any(p.search(text) for p in cls._compiled_rules)
+


### PR DESCRIPTION
## Summary
- add filter API router and mount under `/api/admin`
- create `InputFilter` utility for checking sensitive text
- reload filter rules when filters are modified
- apply input filtering in websocket chat handler

## Testing
- `python -m py_compile backend/main.py backend/filter_api.py backend/core/input_filter.py`

------
https://chatgpt.com/codex/tasks/task_e_6843b7b96714832aa39d3352a002b96f