### PR TITLE
Fix frontend backend URL

### DIFF
--- a/admin-frontend/main.py
+++ b/admin-frontend/main.py
@@ -1,4 +1,5 @@
 
+import os
 import streamlit as st
 import requests
 import json
@@ -9,6 +10,9 @@ st.set_page_config(
     page_icon="⚙️",
     layout="wide"
 )
+
+# 백엔드 접속 URL (환경 변수로 설정 가능)
+BACKEND_URL = os.getenv("BACKEND_URL", "http://backend:8000")
 
 class AdminAPIClient:
     """운영자용 API 클라이언트"""
@@ -166,7 +170,7 @@ def main():
     st.markdown("---")
 
     # API 클라이언트 초기화
-    api_client = AdminAPIClient("http://localhost:8000")
+    api_client = AdminAPIClient(BACKEND_URL)
 
     # ----------------------------------------------------------------------
     # 사이드바: 필터 규칙 관리 UI
@@ -481,7 +485,7 @@ def main():
         with col1:
             st.write("**서버 상태:**")
             try:
-                health_response = requests.get("http://localhost:8000/health", timeout=5)
+                health_response = requests.get(f"{BACKEND_URL}/health", timeout=5)
                 if health_response.status_code == 200:
                     st.success("✅ 백엔드 서버 정상")
                     health_data = health_response.json()

--- a/k8s/admin-frontend.yaml
+++ b/k8s/admin-frontend.yaml
@@ -16,6 +16,9 @@ spec:
         - name: admin-frontend
           image: asia-docker.pkg.dev/architect-certification-289902/admin-frontend/admin-frontend:latest
           command: ["streamlit", "run", "admin-frontend/main.py", "--server.port=8501", "--server.address=0.0.0.0"]
+          env:
+            - name: BACKEND_URL
+              value: http://backend:8000
           ports:
             - containerPort: 8501
 ---

--- a/k8s/user-frontend.yaml
+++ b/k8s/user-frontend.yaml
@@ -16,6 +16,9 @@ spec:
         - name: user-frontend
           image: asia-docker.pkg.dev/architect-certification-289902/user-frontend/user-frontend:latest
           command: ["streamlit", "run", "user-frontend/main.py", "--server.port=8502", "--server.address=0.0.0.0"]
+          env:
+            - name: BACKEND_URL
+              value: http://backend:8000
           ports:
             - containerPort: 8502
 ---

--- a/user-frontend/main.py
+++ b/user-frontend/main.py
@@ -1,3 +1,4 @@
+import os
 import streamlit as st
 import websocket
 import json
@@ -10,6 +11,10 @@ st.set_page_config(
     page_icon="🤖",
     layout="wide"
 )
+
+# 백엔드 접속 URL 설정
+BACKEND_URL = os.getenv("BACKEND_URL", "http://backend:8000")
+BACKEND_WS_URL = BACKEND_URL.replace("http://", "ws://").replace("https://", "wss://")
 
 class UserWebSocketClient:
     """사용자용 웹소켓 클라이언트"""
@@ -100,7 +105,7 @@ def main():
             full_response = ""
             
             # 웹소켓 클라이언트 생성 및 연결
-            client = UserWebSocketClient("ws://localhost:8000/api/user/chat")
+            client = UserWebSocketClient(f"{BACKEND_WS_URL}/api/user/chat")
             
             if client.connect():
                 # 메시지 전송
@@ -135,7 +140,7 @@ def main():
         try:
             import requests
             response = requests.get(
-                "http://localhost:8000/api/user/status",
+                f"{BACKEND_URL}/api/user/status",
                 headers={"Authorization": "Bearer user_token"},
                 timeout=5
             )


### PR DESCRIPTION
## Summary
- let UI components read `BACKEND_URL`
- pass `BACKEND_URL` env variable in k8s deployments

## Testing
- `python -m py_compile admin-frontend/main.py user-frontend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_684767a97e38832a82fa761a9df8ccf7