### PR TITLE
Add script to create secrets from env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,17 @@ pack build user-frontend --path user-frontend --builder paketobuildpacks/builder
 ## Skaffold를 이용한 자동 재배포
 [Skaffold](https://skaffold.dev/)를 사용하면 소스 코드 변경 시 자동으로 빌드와 배포가 이루어집니다.
 
+
+### Kubernetes Secrets
+Secrets can be created from your `.env` file with the helper script:
+
+```bash
+./scripts/create_secrets.sh path/to/.env
+```
+
+This uses `kubectl` to generate the `anthropic-api-key`, `openai-api-key` and `langsmith-api-key` secrets.  If you prefer to edit a file manually, `k8s/secrets.yaml` provides a template that you can apply with:
+
+```bash
+kubectl apply -f k8s/secrets.yaml
+```
+

--- a/k8s/secrets.yaml
+++ b/k8s/secrets.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: anthropic-api-key
+type: Opaque
+stringData:
+  ANTHROPIC_API_KEY: ""
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openai-api-key
+type: Opaque
+stringData:
+  OPENAI_API_KEY: ""
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: langsmith-api-key
+type: Opaque
+stringData:
+  LANGSMITH_API_KEY: ""

--- a/scripts/create_secrets.sh
+++ b/scripts/create_secrets.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Create Kubernetes secrets from an env file.
+# Usage: ./scripts/create_secrets.sh [path_to_env]
+
+set -euo pipefail
+
+ENV_FILE="${1:-.env}"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Env file '$ENV_FILE' not found" >&2
+  exit 1
+fi
+
+set -a
+# shellcheck source=/dev/null
+source "$ENV_FILE"
+set +a
+
+kubectl create secret generic anthropic-api-key \
+  --from-literal=ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create secret generic openai-api-key \
+  --from-literal=OPENAI_API_KEY="$OPENAI_API_KEY" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create secret generic langsmith-api-key \
+  --from-literal=LANGSMITH_API_KEY="$LANGSMITH_API_KEY" \
+  --dry-run=client -o yaml | kubectl apply -f -


### PR DESCRIPTION
## Summary
- add `scripts/create_secrets.sh` to read `.env` and create Kubernetes secrets using kubectl
- update README to document the helper script and reference existing secrets template

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684783b9fcb0832a98d0608a376388f3