### PR TITLE
Update frontend services with ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,19 @@ Docker를 사용해 각 서비스를 컨테이너로 실행할 수 있습니다.
 - admin-frontend: `8501`
 - user-frontend: `8502`
 
-## Paketo Buildpack으로 이미지 빌드
-`pack` CLI가 설치되어 있다면 Paketo Python Buildpack을 사용해 이미지를 생성할 수 있습니다.
-
-```bash
-pack build backend --path backend --builder paketobuildpacks/builder-jammy-base
-pack build admin-frontend --path admin-frontend --builder paketobuildpacks/builder-jammy-base
-pack build user-frontend --path user-frontend --builder paketobuildpacks/builder-jammy-base
-```
 
 ## Skaffold를 이용한 자동 재배포
 [Skaffold](https://skaffold.dev/)를 사용하면 소스 코드 변경 시 자동으로 빌드와 배포가 이루어집니다.
+
+### 기동 테스트
+Kubernetes 클러스터가 준비되었다면 다음 명령으로 서비스를 배포하고 변경 사항을 실시간으로 반영할 수 있습니다.
+
+```bash
+skaffold dev
+```
+
+이 명령은 모든 이미지를 빌드한 후 `k8s` 디렉터리의 매니페스트를 적용하여 애플리케이션을 실행합니다.
+
 
 
 ### Kubernetes Secrets

--- a/k8s/admin-frontend.yaml
+++ b/k8s/admin-frontend.yaml
@@ -32,4 +32,4 @@ spec:
   ports:
     - port: 8501
       targetPort: 8501
-  type: LoadBalancer
+  type: ClusterIP

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend-ingress
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /admin
+            pathType: Prefix
+            backend:
+              service:
+                name: admin-frontend
+                port:
+                  number: 8501
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: user-frontend
+                port:
+                  number: 8502

--- a/k8s/user-frontend.yaml
+++ b/k8s/user-frontend.yaml
@@ -32,4 +32,4 @@ spec:
   ports:
     - port: 8502
       targetPort: 8502
-  type: LoadBalancer
+  type: ClusterIP

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -24,4 +24,5 @@ deploy:
       - k8s/backend.yaml
       - k8s/admin-frontend.yaml
       - k8s/user-frontend.yaml
+      - k8s/ingress.yaml
 


### PR DESCRIPTION
## Summary
- change admin and user frontend services to ClusterIP
- add new ingress for both frontends to share one external IP
- include ingress manifest in skaffold configuration

## Testing
- `grep -n loadBalancerIP k8s/admin-frontend.yaml k8s/user-frontend.yaml`
- `grep -n "frontend-ingress" k8s/ingress.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68482e89ac58832aa6b1ec4dad223a8c