### PR TITLE
Fix admin frontend path with BackendConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ command:
   - "--server.baseUrlPath=/admin"
 ```
 
+서비스 헬스체크는 기본적으로 `/` 경로를 사용합니다. 관리자 페이지가 `/admin` 하위에서 동작하기 때문에 `k8s/backend-config.yaml` 파일로 헬스체크 경로를 `/admin`으로 지정했습니다. Service 메타데이터의 `cloud.google.com/backend-config` 주석을 통해 이를 적용합니다.
+
 이를 통해 `/admin` 접두사가 있는 URL에서도 정적 자산이 올바르게 로드됩니다.
 
 

--- a/k8s/admin-frontend.yaml
+++ b/k8s/admin-frontend.yaml
@@ -34,6 +34,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    cloud.google.com/backend-config: '{"default": "admin-frontend-config"}'
   name: admin-frontend
 spec:
   selector:

--- a/k8s/backend-config.yaml
+++ b/k8s/backend-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: admin-frontend-config
+spec:
+  healthCheck:
+    requestPath: /admin
+    port: 8501


### PR DESCRIPTION
## Summary
- add BackendConfig so GKE health checks use `/admin`
- annotate admin service to reference the config
- document health check setup in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848b68f0dd8832a8483cd48639b2dc8